### PR TITLE
remove ghauth in favor of manually authenticating using an env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,33 @@ Generate a markdown report of your recent activity on GitHub
 
 ## Usage
 
+Create a [GitHub Personal Access Token](https://github.com/settings/tokens/new?scopes=repo&description=npx%20recent-github-activity) with the `repo` scope, then add it to your environment:
+
 ```
-npx recent-github-activity
+export GITHUB_RECENT_ACTIVITY_PERSONAL_ACCESS_TOKEN="ghp_..."
 ```
 
-The first time you run this command, you'll be asked to log in to GitHub using your password or a personal access token, and the resulting token will be saved to disk for future use using [ghauth](https://github.com/rvagg/ghauth).
+Then run:
+
+```
+npx recent-github-activity <username>
+```
+
+If you specify _your own GitHub username_, you'll see all of your recent activity, both public and private.
+
+If you specify someone else's username, you'll see all of their public activity.
+
 
 You can save the output to a file:
 
 ```
-npx recent-github-activity > recent.md
+npx recent-github-activity zeke > recent.md
 ```
 
 or pipe it right to [`vmd`](https://ghub.io/vmd):
 
 ```
-npx recent-github-activity | npx vmd
+npx recent-github-activity zeke | npx vmd
 ```
 
 This is what a generated report looks like in `vmd`:

--- a/lib/events.js
+++ b/lib/events.js
@@ -7,7 +7,7 @@ module.exports = async function getEvents (username) {
   const events = await octokit.paginate(
     'GET /users/:username/events',
     {
-      username: username || octokit.user,
+      username: username,
       per_page: 100
     },
     (response, done) => {

--- a/lib/octokit.js
+++ b/lib/octokit.js
@@ -1,19 +1,9 @@
 const { Octokit } = require('@octokit/core')
 const { paginateRest } = require('@octokit/plugin-paginate-rest')
-const pkg = require('../package.json')
 
 module.exports = async function getOctokit () {
-  const ghauth = require('ghauth')
-  const authOptions = {
-    configName: pkg.name,
-    scopes: ['repo'],
-    note: pkg.description
-  }
-
-  const { user, token: auth } = await ghauth(authOptions)
-
+  const auth = process.env.GITHUB_RECENT_ACTIVITY_PERSONAL_ACCESS_TOKEN
   const MyOctokit = Octokit.plugin(paginateRest)
   const octokit = new MyOctokit({ auth })
-  octokit.user = user
   return octokit
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Generate a markdown report of your recent activity on GitHub",
   "dependencies": {
     "@github-docs/render-content": "^1.0.1",
-    "@octokit/rest": "^17.0.1",
-    "ghauth": "^4.0.0",
+    "@octokit/rest": "^19.0.5",
     "liquid": "^4.0.0",
     "lodash": "^4.17.15",
     "time-ago": "^0.2.1"

--- a/template.md
+++ b/template.md
@@ -4,6 +4,12 @@
 - [{{event.repo.name}}#{{event.payload.issue.number}}]({{ event.payload.issue.html_url }}) {{ event.payload.issue.title }} - {{event.timeago}}
 {%- endfor %}
 
+## Closed Pull Requests
+
+{%- for event in closedPullRequests %}
+- [{{event.repo.name}}#{{event.payload.pull_request.number}}]({{ event.payload.pull_request.html_url }}) {{ event.payload.pull_request.title }} - {{event.timeago}}
+{%- endfor %}
+
 ## Opened Issues
 
 {%- for event in openedIssues %}
@@ -13,11 +19,5 @@
 ## Opened Pull Requests
 
 {%- for event in openedPullRequests %}
-- [{{event.repo.name}}#{{event.payload.pull_request.number}}]({{ event.payload.pull_request.html_url }}) {{ event.payload.pull_request.title }} - {{event.timeago}}
-{%- endfor %}
-
-## Closed Pull Requests
-
-{%- for event in closedPullRequests %}
 - [{{event.repo.name}}#{{event.payload.pull_request.number}}]({{ event.payload.pull_request.html_url }}) {{ event.payload.pull_request.title }} - {{event.timeago}}
 {%- endfor %}


### PR DESCRIPTION
This project used to use an npm package called `ghauth` that did some fancy stuff to fetch your GitHub token and store it locally for future use. Unfortunately that project went through some major changes as GitHub changed their auth requirements over the years. I took a shot at updating but it was Hard™, so I decided to rip it out.

Instead, this project now requires users to manually set an env var with their token.

More work for the user, but at least it makes this old CLI usable again. 🤷🏼 