### PR TITLE
fix: fetch full PR data for titles and URLs in output

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ const username = args[0]
 main()
 
 async function main () {
-
   if (!username) {
     console.error('Usage: github-recent-activity <username>')
     process.exit(0)

--- a/lib/events.js
+++ b/lib/events.js
@@ -17,6 +17,22 @@ module.exports = async function getEvents (username) {
     }
   )
 
+  // Enrich PullRequestEvent payloads with full PR data (title, html_url, etc.)
+  const prEvents = events.filter(e => e.type === 'PullRequestEvent')
+  await Promise.all(prEvents.map(async (event) => {
+    try {
+      const [owner, repo] = event.repo.name.split('/')
+      const { data: pr } = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+        owner,
+        repo,
+        pull_number: event.payload.number
+      })
+      event.payload.pull_request = pr
+    } catch (err) {
+      // If we can't fetch the PR, keep the limited data
+    }
+  }))
+
   return events
     .map(event => {
       event.created_at = new Date(event.created_at)

--- a/template.md
+++ b/template.md
@@ -7,7 +7,7 @@
 ## Closed Pull Requests
 
 {%- for event in closedPullRequests %}
-- [{{event.repo.name}}#{{event.payload.pull_request.number}}]({{ event.payload.pull_request.html_url }}) {{ event.payload.pull_request.title }} - {{event.timeago}}
+- [{{event.repo.name}}#{{event.payload.number}}](https://github.com/{{ event.repo.name }}/pull/{{ event.payload.number }}) {{ event.payload.pull_request.title }} - {{event.timeago}}
 {%- endfor %}
 
 ## Opened Issues
@@ -19,5 +19,5 @@
 ## Opened Pull Requests
 
 {%- for event in openedPullRequests %}
-- [{{event.repo.name}}#{{event.payload.pull_request.number}}]({{ event.payload.pull_request.html_url }}) {{ event.payload.pull_request.title }} - {{event.timeago}}
+- [{{event.repo.name}}#{{event.payload.number}}](https://github.com/{{ event.repo.name }}/pull/{{ event.payload.number }}) {{ event.payload.pull_request.title }} - {{event.timeago}}
 {%- endfor %}


### PR DESCRIPTION
This PR fixes the broken output for pull requests in the activity report.

The GitHub Events API returns a minimal `pull_request` object that lacks `html_url` and `title` fields. This caused:
- Empty URLs: `[repo#123]()` 
- Missing titles

Changes:
- Enrich `PullRequestEvent` payloads by fetching full PR data via the GitHub API
- Construct PR URLs from available data as a fallback

## Testing locally

```sh
gh repo clone zeke/github-modules
cd github-modules/recent-github-activity
git checkout fix-pr-output
npm install
GITHUB_RECENT_ACTIVITY_PERSONAL_ACCESS_TOKEN=ghp_... npx . zeke
```