### PR TITLE
feat: separate merged from closed PRs, hide empty sections

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,22 +46,20 @@ async function main () {
     .filter(event => event.payload.action === 'opened')
     .value()
 
-  const openedPullRequests = chain(events)
+  // Categorize PRs by their current state (not just the event action)
+  const allPREvents = chain(events)
     .filter(event => event.type === 'PullRequestEvent')
     .filter(event => event.payload.action === 'opened')
     .value()
 
-  const mergedPullRequests = chain(events)
-    .filter(event => event.type === 'PullRequestEvent')
-    .filter(event => event.payload.action === 'closed')
-    .filter(event => event.payload.pull_request?.merged)
-    .value()
+  const openedPullRequests = allPREvents
+    .filter(event => event.payload.pull_request?.state === 'open')
 
-  const closedPullRequests = chain(events)
-    .filter(event => event.type === 'PullRequestEvent')
-    .filter(event => event.payload.action === 'closed')
-    .filter(event => !event.payload.pull_request?.merged)
-    .value()
+  const mergedPullRequests = allPREvents
+    .filter(event => event.payload.pull_request?.merged)
+
+  const closedPullRequests = allPREvents
+    .filter(event => event.payload.pull_request?.state === 'closed' && !event.payload.pull_request?.merged)
 
   const context = {
     eventTypes,

--- a/template.md
+++ b/template.md
@@ -1,29 +1,26 @@
+{% if closedIssues.size > 0 %}
 ## Closed Issues
-
-{%- for event in closedIssues %}
+{% for event in closedIssues %}
 - [{{event.repo.name}}#{{event.payload.issue.number}}]({{ event.payload.issue.html_url }}) {{ event.payload.issue.title }} - {{event.timeago}}
 {%- endfor %}
-
+{% endif %}{% if mergedPullRequests.size > 0 %}
 ## Merged Pull Requests
-
-{%- for event in mergedPullRequests %}
+{% for event in mergedPullRequests %}
 - [{{event.repo.name}}#{{event.payload.number}}](https://github.com/{{ event.repo.name }}/pull/{{ event.payload.number }}) {{ event.payload.pull_request.title }} - {{event.timeago}}
 {%- endfor %}
-
+{% endif %}{% if closedPullRequests.size > 0 %}
 ## Closed Pull Requests
-
-{%- for event in closedPullRequests %}
+{% for event in closedPullRequests %}
 - [{{event.repo.name}}#{{event.payload.number}}](https://github.com/{{ event.repo.name }}/pull/{{ event.payload.number }}) {{ event.payload.pull_request.title }} - {{event.timeago}}
 {%- endfor %}
-
+{% endif %}{% if openedIssues.size > 0 %}
 ## Opened Issues
-
-{%- for event in openedIssues %}
+{% for event in openedIssues %}
 - [{{event.repo.name}}#{{event.payload.issue.number}}]({{ event.payload.issue.html_url }}) {{ event.payload.issue.title }} - {{event.timeago}}
 {%- endfor %}
-
+{% endif %}{% if openedPullRequests.size > 0 %}
 ## Opened Pull Requests
-
-{%- for event in openedPullRequests %}
+{% for event in openedPullRequests %}
 - [{{event.repo.name}}#{{event.payload.number}}](https://github.com/{{ event.repo.name }}/pull/{{ event.payload.number }}) {{ event.payload.pull_request.title }} - {{event.timeago}}
 {%- endfor %}
+{% endif %}


### PR DESCRIPTION
This PR improves the activity report output:

- Separates "Merged Pull Requests" from "Closed Pull Requests" (unmerged)
- Hides section headings when there are no results

## Testing locally

```sh
gh repo clone zeke/github-modules
cd github-modules/recent-github-activity
git checkout improve-pr-output
npm install
GITHUB_RECENT_ACTIVITY_PERSONAL_ACCESS_TOKEN=ghp_... npx . zeke
```